### PR TITLE
Avoid NPE in OSGi if UI is not instantiated yet

### DIFF
--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/builder/AppLayoutBuilder.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/builder/AppLayoutBuilder.java
@@ -282,9 +282,13 @@ public class AppLayoutBuilder {
 
     public AppLayout build() {
         if (instance == null) {
-            if (!UI.getCurrent().getPage().getWebBrowser().isIE()) {
-                instance = variant.getInstance();
-            } else {
+            try {
+                if (!UI.getCurrent().getPage().getWebBrowser().isIE()) {
+                    instance = variant.getInstance();
+                } else {
+                    instance = new LeftFallBack(variant);
+                }
+            } catch (Execption e) {
                 instance = new LeftFallBack(variant);
             }
             AppLayoutSessionHelper.setActiveVariant(variant);


### PR DESCRIPTION
In OSGi the AppLayout may be build before the UI exists, thus the UI.getCurrent() throws a NPE.

Alex