### PR TITLE
fix "Show All" Button having no effect

### DIFF
--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/notification/component/NotificationsView.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/notification/component/NotificationsView.java
@@ -34,7 +34,7 @@ public class NotificationsView extends Composite<VerticalLayout> {
 
         content.removeAll();
         if (holder.getNotificationSize() > 0) {
-            content.add(this.holder.getNotificationViews(false));
+			content.add(this.holder.getNotificationViews(showAll.value));
             getElement().getClassList().add(Styles.APP_BAR_NOTIFICATION_LIST);
 
             if (!showAll.value && this.holder.getNotificationSize() > 4) {


### PR DESCRIPTION
this fixes the "Show All"  Button in the notification view. 
Pressing it had no effect before, because getNotifications was always called with "false"