### PR TITLE
Allow building the app-layout without any menu elements

### DIFF
--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/AppLayoutElementBase.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/AppLayoutElementBase.java
@@ -35,4 +35,7 @@ public interface AppLayoutElementBase extends NavigationElementContainer {
     void setAppBar(Component component);
 
     void setAppMenu(NavigationElementContainer component);
+
+    default void init() {
+    }
 }

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/left/AbstractLeftAppLayoutBase.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/left/AbstractLeftAppLayoutBase.java
@@ -24,161 +24,184 @@ import java.util.Optional;
 
 public abstract class AbstractLeftAppLayoutBase extends AppLayout {
 
-  @Id("toggle")
-  private PaperIconButton paperIconButton;
-  @Id("app-bar-elements")
-  private Div appBarElements;
-  @Id("menu-elements")
-  private Div menuElements;
-  @Id("content")
-  private Div content;
-  @Id("drawer")
-  private AppDrawer drawer;
+    private final HorizontalLayout appBarElementWrapper = new HorizontalLayout();
+    private final HorizontalLayout appBarElementContainer = new HorizontalLayout();
+    private final HorizontalLayout titleWrapper = new HorizontalLayout();
+    @Id("toggle")
+    private PaperIconButton paperIconButton;
+    @Id("app-bar-elements")
+    private Div appBarElements;
+    @Id("menu-elements")
+    private Div menuElements;
+    @Id("content")
+    private Div content;
+    @Id("drawer")
+    private AppDrawer drawer;
+    private Component title;
+    private NavigationElementContainer appMenuContainer;
+    private HasElement appLayoutContent;
+    private boolean isMenuVisible = true;
 
-  private final HorizontalLayout appBarElementWrapper = new HorizontalLayout();
-  private final HorizontalLayout appBarElementContainer = new HorizontalLayout();
-  private final HorizontalLayout titleWrapper = new HorizontalLayout();
-  private Component title;
-  private NavigationElementContainer appMenuContainer;
+    public AbstractLeftAppLayoutBase() {
+        super();
+        getStyle().set("width", "100%")
+                .set("height", "100%");
+        getClassNames().addAll(Arrays.asList("app-layout-behaviour-" + getStyleName(), Styles.APP_LAYOUT));
+        HorizontalLayout appBarContentHolder = new HorizontalLayout(titleWrapper, appBarElementWrapper);
+        appBarContentHolder.setSizeFull();
+        appBarElements.add(appBarContentHolder);
 
-  public AbstractLeftAppLayoutBase() {
-    super();
-    getStyle().set("width" , "100%")
-              .set("height" , "100%");
-    getClassNames().addAll(Arrays.asList("app-layout-behaviour-" + getStyleName() , Styles.APP_LAYOUT));
-    HorizontalLayout appBarContentHolder = new HorizontalLayout(titleWrapper , appBarElementWrapper);
-    appBarContentHolder.setSizeFull();
-    appBarElements.add(appBarContentHolder);
+        appBarElementWrapper.setSpacing(false);
+        appBarElementWrapper.setSizeFull();
+        appBarElementWrapper.add(appBarElementContainer);
+        appBarElementContainer.setHeight("100%");
+        appBarElementWrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
 
-    appBarElementWrapper.setSpacing(false);
-    appBarElementWrapper.setSizeFull();
-    appBarElementWrapper.add(appBarElementContainer);
-    appBarElementContainer.setHeight("100%");
-    appBarElementWrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
-
-    titleWrapper.setHeight("100%");
-    titleWrapper.setAlignItems(FlexComponent.Alignment.CENTER);
-    titleWrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
-    titleWrapper.setPadding(false);
-    titleWrapper.setMargin(false);
-    getElement().getClassList().add("app-layout");
-  }
-
-  @Override
-  public AppDrawer getDrawer() {
-    return drawer;
-  }
-
-  public abstract String getStyleName();
-
-  public void setDesign(AppLayoutDesign design) {
-    this.getElement().getClassList().add(design.getStyleName());
-  }
-
-  public HorizontalLayout getAppBarElementWrapper() {
-    return appBarElementWrapper;
-  }
-
-  public Component getTitleLabel() {
-    return title;
-  }
-
-  public void setIconComponent(Component appBarIconComponent) {
-    titleWrapper.getElement().insertChild(0 , appBarIconComponent.getElement());
-    titleWrapper.setAlignItems(FlexComponent.Alignment.CENTER);
-  }
-
-  @Override
-  public void setAppLayoutContent(HasElement content) {
-    if (content != null) {
-      this.content.getElement().appendChild(content.getElement());
-      setUpBackNavigation(content);
+        titleWrapper.setHeight("100%");
+        titleWrapper.setAlignItems(FlexComponent.Alignment.CENTER);
+        titleWrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+        titleWrapper.setPadding(false);
+        titleWrapper.setMargin(false);
+        getElement().getClassList().add("app-layout");
     }
-  }
 
-  private void setUpBackNavigation(HasElement content) {
-    if (content instanceof HasBackNavigation) {
-      paperIconButton.setIcon("back");
-    } else {
-      paperIconButton.setIcon("menu");
+    @Override
+    public AppDrawer getDrawer() {
+        return drawer;
     }
-  }
 
-  @Override
-  public void setAppBar(Component component) {
-    appBarElementContainer.removeAll();
-    appBarElementContainer.add(component);
-  }
+    public abstract String getStyleName();
 
-  @Override
-  public void setAppMenu(NavigationElementContainer container) {
-    menuElements.removeAll();
-    menuElements.add(container.getComponent());
-    appMenuContainer = container;
-  }
-
-  @Override
-  public Component getTitleComponent() {
-    return title;
-  }
-
-  public void setTitleComponent(Component component) {
-    titleWrapper.replace(this.title , component);
-    this.title = component;
-    titleWrapper.setAlignItems(FlexComponent.Alignment.CENTER);
-  }
-
-  public HorizontalLayout getTitleWrapper() {
-    return titleWrapper;
-  }
-
-  @Override
-  public void setBackNavigation(boolean visible) {
-    paperIconButton.setIcon(visible ? "arrow-back" : "menu");
-  }
-
-  @Override
-  public boolean setActiveNavigationComponent(Class<? extends HasElement> element) {
-    if (appMenuContainer != null) {
-      return appMenuContainer.setActiveNavigationComponent(element);
+    public void setDesign(AppLayoutDesign design) {
+        this.getElement().getClassList().add(design.getStyleName());
     }
-    return false;
-  }
 
-  @Override
-  public Optional<Class<? extends HasElement>> getClosestNavigationElement(Class<? extends HasElement> element) {
-    if (appMenuContainer != null) {
-      return appMenuContainer.getClosestNavigationElement(element);
+    public HorizontalLayout getAppBarElementWrapper() {
+        return appBarElementWrapper;
     }
-    return Optional.empty();
-  }
 
-  @Override
-  public Component getComponent() {
-    return this;
-  }
+    public Component getTitleLabel() {
+        return title;
+    }
 
-  @Override
-  public void init() {
+    public void setIconComponent(Component appBarIconComponent) {
+        titleWrapper.getElement().insertChild(0, appBarIconComponent.getElement());
+        titleWrapper.setAlignItems(FlexComponent.Alignment.CENTER);
+    }
+
+    @Override
+    public void setAppLayoutContent(HasElement content) {
+        if (content != null) {
+            this.content.getElement().appendChild(content.getElement());
+            setUpBackNavigation(content);
+        }
+    }
+
+    private void setUpBackNavigation(HasElement content) {
+        if (content instanceof HasBackNavigation) {
+            paperIconButton.setIcon("back");
+        } else {
+            paperIconButton.setIcon("menu");
+        }
+    }
+
+    @Override
+    public void setAppBar(Component component) {
+        appBarElementContainer.removeAll();
+        appBarElementContainer.add(component);
+    }
+
+    @Override
+    public void setAppMenu(NavigationElementContainer container) {
+        menuElements.removeAll();
+        menuElements.add(container.getComponent());
+        appMenuContainer = container;
+    }
+
+    @Override
+    public Component getTitleComponent() {
+        return title;
+    }
+
+    public void setTitleComponent(Component component) {
+        titleWrapper.replace(this.title, component);
+        this.title = component;
+        titleWrapper.setAlignItems(FlexComponent.Alignment.CENTER);
+    }
+
+    public HorizontalLayout getTitleWrapper() {
+        return titleWrapper;
+    }
+
+    @Override
+    public void setBackNavigation(boolean visible) {
+        paperIconButton.setIcon(visible ? "arrow-back" : "menu");
+    }
+
+    @Override
+    public boolean setActiveNavigationComponent(Class<? extends HasElement> element) {
+        if (appMenuContainer != null) {
+            return appMenuContainer.setActiveNavigationComponent(element);
+        }
+        return false;
+    }
+
+    @Override
+    public Optional<Class<? extends HasElement>> getClosestNavigationElement(Class<? extends HasElement> element) {
+        if (appMenuContainer != null) {
+            return appMenuContainer.getClosestNavigationElement(element);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Component getComponent() {
+        return this;
+    }
+
+    @Override
+    public void init() {
+        /**
+         * if no menu elements were added hide the button and menu
+         */
+        if (appMenuContainer == null) {
+            setMenuVisible(false);
+        }
+    }
+
     /**
-     * if no menu elements were added hide the button and menu
+     * Weather the menu is currently hidden or not.
+     *
+     * @return false of the menu is currently hidden.
      */
-    if (appMenuContainer == null) {
-      hideMenu(true);
+    public boolean isMenuVisible() {
+        return isMenuVisible;
     }
-  }
 
-  public void hideMenu(boolean hide) {
-    if (hide) {
-      drawer.getElement().getStyle().set("display", "none");
-      paperIconButton.getElement().getStyle().set("display", "none");
-      getElement().getStyle().set("--app-layout-drawer-width", "0px");
-      getElement().getStyle().set("--app-layout-drawer-small-width", "0px");
-    } else {
-      drawer.getElement().getStyle().remove("display");
-      paperIconButton.getElement().getStyle().remove("display");
-      getElement().getStyle().remove("--app-layout-drawer-width");
-      getElement().getStyle().remove("--app-layout-drawer-small-width");
+    /**
+     * Hiding the menu will hide all menu elements also on the client side.
+     * </br> Note that you still have to make sure that an unauthorized user is unable to access the paths available in the menu!
+     *
+     * @param isMenuVisible
+     */
+    public void setMenuVisible(boolean isMenuVisible) {
+        if (isMenuVisible != this.isMenuVisible) { // only do something if the state was changed
+            this.isMenuVisible = isMenuVisible;
+            if (isMenuVisible) {
+                if (menuElements.getChildren().count() == 0 && appMenuContainer != null) { // if the container is empty add the component
+                    menuElements.add(appMenuContainer.getComponent());
+                }
+                drawer.getElement().getStyle().remove("display");
+                paperIconButton.getElement().getStyle().remove("display");
+                getElement().getStyle().remove("--app-layout-drawer-width");
+                getElement().getStyle().remove("--app-layout-drawer-small-width");
+            } else {
+                drawer.getElement().getStyle().set("display", "none");
+                menuElements.removeAll();
+                paperIconButton.getElement().getStyle().set("display", "none");
+                getElement().getStyle().set("--app-layout-drawer-width", "0px");
+                getElement().getStyle().set("--app-layout-drawer-small-width", "0px");
+            }
+        }
     }
-  }
 }

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/left/AbstractLeftAppLayoutBase.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/left/AbstractLeftAppLayoutBase.java
@@ -161,7 +161,7 @@ public abstract class AbstractLeftAppLayoutBase extends AppLayout {
   @Override
   public void init() {
     /**
-     * if no menu elements were hide the button and menu
+     * if no menu elements were added hide the button and menu
      */
     if (appMenuContainer == null) {
       hideMenu(true);

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/left/AbstractLeftAppLayoutBase.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/left/AbstractLeftAppLayoutBase.java
@@ -1,7 +1,5 @@
 package com.github.appreciated.app.layout.behaviour.left;
 
-import java.util.Arrays;
-
 import com.github.appreciated.app.layout.behaviour.AppLayout;
 import com.github.appreciated.app.layout.behaviour.AppLayoutElementBase;
 import com.github.appreciated.app.layout.builder.interfaces.NavigationElementContainer;
@@ -16,6 +14,9 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.polymertemplate.Id;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * The {@link AbstractLeftAppLayoutBase} is the supposed to be the base of any {@link AppLayoutElementBase} with a "Left Behaviour".
@@ -138,16 +139,46 @@ public abstract class AbstractLeftAppLayoutBase extends AppLayout {
 
   @Override
   public boolean setActiveNavigationComponent(Class<? extends HasElement> element) {
-    return appMenuContainer.setActiveNavigationComponent(element);
+    if (appMenuContainer != null) {
+      return appMenuContainer.setActiveNavigationComponent(element);
+    }
+    return false;
   }
 
   @Override
-  public Class<? extends HasElement> getClosestNavigationElement(Class<? extends HasElement> element) {
-    return appMenuContainer.getClosestNavigationElement(element);
+  public Optional<Class<? extends HasElement>> getClosestNavigationElement(Class<? extends HasElement> element) {
+    if (appMenuContainer != null) {
+      return appMenuContainer.getClosestNavigationElement(element);
+    }
+    return Optional.empty();
   }
 
   @Override
   public Component getComponent() {
     return this;
+  }
+
+  @Override
+  public void init() {
+    /**
+     * if no menu elements were hide the button and menu
+     */
+    if (appMenuContainer == null) {
+      hideMenu(true);
+    }
+  }
+
+  public void hideMenu(boolean hide) {
+    if (hide) {
+      drawer.getElement().getStyle().set("display", "none");
+      paperIconButton.getElement().getStyle().set("display", "none");
+      getElement().getStyle().set("--app-layout-drawer-width", "0px");
+      getElement().getStyle().set("--app-layout-drawer-small-width", "0px");
+    } else {
+      drawer.getElement().getStyle().remove("display");
+      paperIconButton.getElement().getStyle().remove("display");
+      getElement().getStyle().remove("--app-layout-drawer-width");
+      getElement().getStyle().remove("--app-layout-drawer-small-width");
+    }
   }
 }

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/builder/AppLayoutBuilder.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/builder/AppLayoutBuilder.java
@@ -77,6 +77,7 @@ public class AppLayoutBuilder implements ComponentBuilder {
         if (imageComponent != null) {
             instance.setIconComponent(imageComponent);
         }
+        instance.init();
         return instance;
 
     }

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/builder/interfaces/NavigationElementContainer.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/builder/interfaces/NavigationElementContainer.java
@@ -26,8 +26,8 @@ public interface NavigationElementContainer extends NavigationElement {
                 .reduce((first, next) -> first || next).orElse(false);
     }
 
-    default Class<? extends HasElement> getClosestNavigationElement(Class<? extends HasElement> element) {
-        return getClosestNavigationElement(getChildren(), element);
+    default Optional<Class<? extends HasElement>> getClosestNavigationElement(Class<? extends HasElement> element) {
+        return Optional.of(getClosestNavigationElement(getChildren(), element));
     }
 
     default Class<? extends HasElement> getClosestNavigationElement(Stream<Component> elements, Class<? extends HasElement> content) {
@@ -38,7 +38,7 @@ public interface NavigationElementContainer extends NavigationElement {
                         Class<? extends HasElement> result = ((NavigationElementComponent) component).getNavigationElement();
                         return result;
                     } else {
-                        Class<? extends HasElement> result = ((NavigationElementContainer) component).getClosestNavigationElement(content);
+                        Class<? extends HasElement> result = ((NavigationElementContainer) component).getClosestNavigationElement(content).get();
                         return result;
                     }
                 })

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/component/appmenu/left/LeftSubmenuComponent.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/component/appmenu/left/LeftSubmenuComponent.java
@@ -9,6 +9,7 @@ import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.icon.Icon;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The component which is used for submenu webcomponents. On click it toggles a css class which causes it to grow / shrink
@@ -48,8 +49,8 @@ public class LeftSubmenuComponent extends AppSubmenu implements NavigationElemen
     }
 
     @Override
-    public Class<? extends HasElement> getClosestNavigationElement(Class<? extends HasElement> element) {
-        return getClosestNavigationElement(getMenu().getChildren(), element);
+    public Optional<Class<? extends HasElement>> getClosestNavigationElement(Class<? extends HasElement> element) {
+        return Optional.of(getClosestNavigationElement(getMenu().getChildren(), element));
     }
 
     @Override

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/router/AppLayoutRouterLayout.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/router/AppLayoutRouterLayout.java
@@ -49,8 +49,9 @@ public abstract class AppLayoutRouterLayout extends Div implements RouterLayout 
             int value = content.getClass().getAnnotation(Route.class).value().split("/").length;
             getInternalAppLayout().setBackNavigation(value > 1);
             if (!getInternalAppLayout().setActiveNavigationComponent(content.getClass())) {
-                Class<? extends HasElement> closestElement = getInternalAppLayout().getClosestNavigationElement(content.getClass());
-                getInternalAppLayout().setActiveNavigationComponent(closestElement);
+                getInternalAppLayout().getClosestNavigationElement(content.getClass()).ifPresent(aClass -> {
+                    getInternalAppLayout().setActiveNavigationComponent(aClass);
+                });
             }
         }
     }


### PR DESCRIPTION
If the Menu is now build without any elements the menu won't be shown at all. This is especially important if a view doesn't have any menu elements but still wants to show the app bar on the top (f.e. consitency reasons). 
- Added method method to hide and to show `Left...` menus at runtime. 
- fixes #164