### PR TITLE
Close #237

### DIFF
--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
@@ -105,7 +105,7 @@ public interface LeftLayouts {
 
   @Tag("app-layout-left-responsive-overlay")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-overlay.html")
-  class LeftResponsiveOverlay extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveOverlay extends AbstractLeftResponsive {
 
       @Override
       public String getStyleName() {
@@ -115,7 +115,7 @@ public interface LeftLayouts {
 
   @Tag("app-layout-left-responsive-overlay-no-app-bar")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-overlay-no-app-bar.html")
-  class LeftResponsiveOverlayNoAppBar extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveOverlayNoAppBar extends AbstractLeftResponsive {
 
       @Override
       public String getStyleName() {

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
@@ -51,9 +51,18 @@ public interface LeftLayouts {
       }
   }
 
+  abstract class AbstractLeftResponsive extends AbstractLeftAppLayoutBase {
+
+      /** Sets the responsive width. */
+      public void setResponsiveWidth(String width) {
+          getElement().setProperty("responsiveWidth", width);
+      }
+
+  }
+
   @Tag("app-layout-left-responsive")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive.html")
-  class LeftResponsive extends AbstractLeftAppLayoutBase {
+  class LeftResponsive extends AbstractLeftResponsive {
 
       @Override
       public String getStyleName() {

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
@@ -70,10 +70,25 @@ public interface LeftLayouts {
       }
   }
 
+  abstract class AbstractLeftResponsiveHybrid extends AbstractLeftAppLayoutBase {
+
+      /** Sets the responsive width for narrow-mode. */
+      public void setResponsiveWidthNarrow(String width) {
+          getElement().setProperty("responsiveWidthNarrow", width);
+      }
+
+      /** Sets the responsive width for wide-mode. */
+      public void setResponsiveWidthWide(String width) {
+          getElement().setProperty("responsiveWidthWide", width);
+      }
+
+  }
+
+
   @Tag("app-layout-left-responsive-hybrid")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-hybrid.html")
   @StyleSheet("frontend://src/com/github/appreciated/app-layout/left/left-responsive-hybrid.css")
-  class LeftResponsiveHybrid extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveHybrid extends AbstractLeftResponsiveHybrid {
 
       @Override
       public String getStyleName() {
@@ -84,7 +99,7 @@ public interface LeftLayouts {
   @Tag("app-layout-left-responsive-hybrid-no-app-bar")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-hybrid-no-app-bar.html")
   @StyleSheet("frontend://src/com/github/appreciated/app-layout/left/left-responsive-hybrid-no-app-bar.css")
-  class LeftResponsiveHybridNoAppBar extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveHybridNoAppBar extends AbstractLeftResponsiveHybrid {
 
       @Override
       public String getStyleName() {
@@ -95,7 +110,7 @@ public interface LeftLayouts {
   @Tag("app-layout-left-responsive-hybrid-overlay-no-app-bar")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.html")
   @StyleSheet("frontend://src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.css")
-  class LeftResponsiveHybridOverlayNoAppBar extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveHybridOverlayNoAppBar extends AbstractLeftResponsiveHybrid {
 
       @Override
       public String getStyleName() {

--- a/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
+++ b/app-layout-addon/src/main/java/com/github/appreciated/app/layout/behaviour/LeftLayouts.java
@@ -126,7 +126,7 @@ public interface LeftLayouts {
   @Tag("app-layout-left-responsive-small")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-small.html")
   @StyleSheet("frontend://src/com/github/appreciated/app-layout/left/left-responsive-small.css")
-  class LeftResponsiveSmall extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveSmall extends AbstractLeftResponsive {
 
       @Override
       public String getStyleName() {
@@ -137,7 +137,7 @@ public interface LeftLayouts {
   @Tag("app-layout-left-responsive-small-no-app-bar")
   @HtmlImport("frontend://src/com/github/appreciated/app-layout/left/left-responsive-small-no-app-bar.html")
   @StyleSheet("frontend://src/com/github/appreciated/app-layout/left/left-responsive-small-no-app-bar.css")
-  class LeftResponsiveSmallNoAppBar extends AbstractLeftAppLayoutBase {
+  class LeftResponsiveSmallNoAppBar extends AbstractLeftResponsive {
 
       @Override
       public String getStyleName() {

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-no-app-bar.css
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-no-app-bar.css
@@ -1,23 +1,24 @@
-@media only screen and (min-width: 640px) {
-    app-layout-left-responsive-hybrid-no-app-bar #menu-header-title, app-layout-left-responsive-hybrid-no-app-bar #menu-header-subtitle {
-        opacity: 1.0;
-        transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
-        max-height: 50px;
-    }
-
-    app-layout-left-responsive-hybrid-no-app-bar #menu-header-wrapper {
-        transition: padding 0.5s;
-    }
+app-layout-left-responsive-hybrid-no-app-bar:not([narrow]) #menu-header-title,
+app-layout-left-responsive-hybrid-no-app-bar:not([narrow]) #menu-header-subtitle
+{
+    opacity: 1.0;
+    transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
+    max-height: 50px;
 }
 
-@media only screen and (min-width: 641px) and (max-width: 1024px) {
-    app-layout-left-responsive-hybrid-no-app-bar #menu-header-title, app-layout-left-responsive-hybrid-no-app-bar #menu-header-subtitle {
-        opacity: 0;
-        max-height: 0px;
-        margin-top: 0px;
-    }
+app-layout-left-responsive-hybrid-no-app-bar:not([narrow]) #menu-header-wrapper {
+    transition: padding 0.5s;
+    margin-top: 0px;
+}
 
-    app-layout-left-responsive-hybrid-no-app-bar #menu-header-wrapper {
-        padding: 4px;
-    }
+app-layout-left-responsive-hybrid-no-app-bar:not([narrow]):not([wide]) #menu-header-title,
+app-layout-left-responsive-hybrid-no-app-bar:not([narrow]):not([wide]) #menu-header-subtitle
+{
+    opacity: 0;
+    max-height: 0px;
+    margin-top: 0px;
+}
+
+app-layout-left-responsive-hybrid-no-app-bar:not([narrow]):not([wide]) #menu-header-wrapper {
+    padding: 4px;
 }

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-no-app-bar.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-no-app-bar.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive-hybrid-no-app-bar">
     <template>
@@ -83,12 +84,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 margin-left: -8px;
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle[icon="menu"] {
-                    display: none;
-                }
-            }
-
             .application-content {
                 width: 100%;
                 height: 100%;
@@ -96,41 +91,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: var(--app-layout-background);
             }
 
-            @media only screen and (max-width: 640px) {
-                .application-content {
-                    padding-top: var(--app-layout-bar-height);
-                    box-sizing: border-box;
-                }
+            :host([narrow]) .application-content {
+                padding-top: var(--app-layout-bar-height);
+                box-sizing: border-box;
             }
 
-            @media only screen and (min-width: 640px) {
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
+            }
 
-                /* no-app-bar */
-                app-header {
-                    display: none;
-                }
+            :host(:not([narrow])) app-header {
+                display: none;
+            }
 
-                #drawer {
-                    margin-top: 0px;
-                }
+            :host(:not([narrow])) #drawer {
+                margin-top: 0px;
+            }
 
-                /* no-app-bar */
-                /* hybrid */
-                #menu-header-title, #menu-header-subtitle {
-                    opacity: 1.0;
-                    transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
-                    max-height: 50px;
-                }
+            :host(:not([narrow])) #drawer {
+                transition: padding 0.5s;
+            }
 
-                #menu-header-wrapper {
-                    transition: padding 0.5s;
-                }
-
-                app-menu-icon-item {
-                    transition: color 0.2s ease;
-                }
-
-                /* hybrid */
+            :host(:not([narrow])) app-menu-icon-item {
+                transition: color 0.2s ease;
             }
 
             #drawerLayout {
@@ -141,46 +124,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: transparent;
             }
 
-            @media only screen and (min-width: 641px) and (max-width: 1024px) {
-                /* hybrid */
-                #drawerLayout {
-                    --app-drawer-width: var(--app-layout-drawer-small-width);
-                    --app-layout-badge-width: var(--app-layout-badge-small-width);
-                    --app-layout-badge-height: var(--app-layout-badge-small-height);
-                    --app-layout-badge-top: var(--app-layout-badge-small-top);
-                    --app-layout-badge-right: var(--app-layout-badge-small-right);
-                    --app-layout-badge-color: transparent;
-                    --app-layout-menu-button-margin: 0;
-                    --app-layout-menu-button-padding: 0 21px;
-                    --app-layout-menu-padding: 0;
-                }
+            :host(:not([narrow]):not([wide])) #drawerLayout {
+                --app-drawer-width: var(--app-layout-drawer-small-width);
+                --app-layout-badge-width: var(--app-layout-badge-small-width);
+                --app-layout-badge-height: var(--app-layout-badge-small-height);
+                --app-layout-badge-top: var(--app-layout-badge-small-top);
+                --app-layout-badge-right: var(--app-layout-badge-small-right);
+                --app-layout-badge-color: transparent;
+                --app-layout-menu-button-margin: 0;
+                --app-layout-menu-button-padding: 0 21px;
+                --app-layout-menu-padding: 0;
+            }
 
-                #drawerLayout .app-menu-item {
-                    overflow: hidden;
-                }
+            :host(:not([narrow]):not([wide])) #drawerLayout .app-menu-item {
+                overflow: hidden;
+            }
 
-                #drawerLayout iron-icon[icon="icons:expand-more"], #drawerLayout iron-icon[icon="expand-more"],
-                #drawerLayout iron-icon[icon="icons:expand-less"], #drawerLayout iron-icon[icon="expand-less"] {
-                    color: transparent;
-                }
+            :host(:not([narrow]):not([wide])) #drawerLayout iron-icon[icon="icons:expand-more"],
+            :host(:not([narrow]):not([wide])) #drawerLayout iron-icon[icon="expand-more"],
+            :host(:not([narrow]):not([wide])) #drawerLayout iron-icon[icon="icons:expand-more"],
+            :host(:not([narrow]):not([wide])) #drawerLayout iron-icon[icon="expand-more"]
+            {
+                color: transparent;
+            }
 
-                #drawerLayout #menu-header-title, #drawerLayout #menu-header-subtitle {
-                    opacity: 0;
-                    max-height: 0px;
-                    margin-top: 0px;
-                }
-
-                #drawerLayout #menu-header-wrapper {
-                    padding: 4px;
-                }
-
-                #drawerLayout * {
-                    --expand-icon-fill-color: transparent !important;
-                    --app-layout-badge-font-color: transparent;
-                }
-
-                /* hybrid */
-
+            :host(:not([narrow]):not([wide]))  #drawerLayout * {
+                --expand-icon-fill-color: transparent !important;
+                --app-layout-badge-font-color: transparent;
             }
         </style>
         <app-header-layout id="layout-wrapper" fullbleed>
@@ -205,11 +175,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </div>
             </app-drawer-layout>
         </app-header-layout>
+        <iron-media-query query="[[_computeNarrowMediaQuery(responsiveWidthNarrow)]]" on-query-matches-changed="_onNarrowQueryMatchesChanged"></iron-media-query>
+        <iron-media-query query="[[_computeWideMediaQuery(responsiveWidthWide)]]" on-query-matches-changed="_onWideQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveHybridNoAppBar extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-hybrid-no-app-bar'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidthNarrow: {
+                        type: String,
+                        value: "640px",
+                    },
+                    responsiveWidthWide: {
+                        type: String,
+                        value: "1024px",
+                    },
+                };
+            }
+
+            static get observers() {
+                return [
+                    "_responsiveWidthChanged(responsiveWidthNarrow, responsiveWidthWide)"
+                ];
             }
 
             onclick() {
@@ -230,6 +221,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidthNarrow;
+            }
+
+            _onNarrowQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+            _onWideQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("wide", "");
+                else
+                    this.removeAttribute("wide");
+            }
+
+            _computeNarrowMediaQuery(responsiveWidthNarrow) {
+                return "(max-width: " + responsiveWidthNarrow + ")";
+            }
+
+            _computeWideMediaQuery(responsiveWidthWide) {
+                return "(min-width: " + responsiveWidthWide + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.css
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.css
@@ -1,23 +1,23 @@
-@media only screen and (min-width: 640px) {
-    app-layout-left-responsive-hybrid-overlay-no-app-bar #menu-header-title, app-layout-left-responsive-hybrid-overlay-no-app-bar #menu-header-subtitle {
-        opacity: 1.0;
-        transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
-        max-height: 50px;
-    }
-
-    app-layout-left-responsive-hybrid-overlay-no-app-bar #menu-header-wrapper {
-        transition: padding 0.5s;
-    }
+app-layout-left-responsive-hybrid-overlay-no-app-bar:not([narrow]) #menu-header-title,
+app-layout-left-responsive-hybrid-overlay-no-app-bar:not([narrow]) #menu-header-subtitle
+{
+    opacity: 1.0;
+    transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
+    max-height: 50px;
 }
 
-@media only screen and (min-width: 641px) and (max-width: 1024px) {
-    app-layout-left-responsive-hybrid-overlay-no-app-bar #menu-header-title, app-layout-left-responsive-hybrid-overlay-no-app-bar #menu-header-subtitle {
-        opacity: 0;
-        max-height: 0px;
-        margin-top: 0px;
-    }
+app-layout-left-responsive-hybrid-overlay-no-app-bar:not([narrow]) #menu-header-wrapper {
+    transition: padding 0.5s;
+}
 
-    app-layout-left-responsive-hybrid-overlay-no-app-bar #menu-header-wrapper {
-        padding: 4px;
-    }
+app-layout-left-responsive-hybrid-overlay-no-app-bar:not([narrow]):not([wide]) #menu-header-title,
+app-layout-left-responsive-hybrid-overlay-no-app-bar:not([narrow]):not([wide]) #menu-header-subtitle
+{
+    opacity: 0;
+    max-height: 0px;
+    margin-top: 0px;
+}
+
+app-layout-left-responsive-hybrid-overlay-no-app-bar:not([narrow]):not([wide]) #menu-header-wrapper {
+    padding: 4px;
 }

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive-hybrid-overlay-no-app-bar">
     <template>

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid-overlay-no-app-bar.html
@@ -76,27 +76,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 margin-left: -8px;
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle[icon="menu"] {
-                    display: none;
-                }
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
             }
 
-            @media only screen and (min-width: 640px) {
-                /* no-app-bar */
-                app-header {
-                    display: none;
-                }
+            :host(:not([narrow])) app-header {
+                display: none;
+            }
 
-                #drawer {
-                    margin-top: 0px;
-                }
+            :host(:not([narrow])) #drawer {
+                margin-top: 0px;
+            }
 
-                app-menu-icon-item {
-                    transition: color 0.2s ease;
-                }
-
-                /* hybrid */
+            :host(:not([narrow])) app-menu-icon-item {
+                transition: color 0.2s ease;
             }
 
             .application-content {
@@ -106,11 +99,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: var(--app-layout-background);
             }
 
-            @media only screen and (max-width: 640px) {
-                .application-content {
-                    box-sizing: border-box;
-                    padding-top: var(--app-layout-bar-height);
-                }
+            :host([narrow]) .application-content {
+                box-sizing: border-box;
+                padding-top: var(--app-layout-bar-height);
             }
 
             #drawerLayout {
@@ -121,30 +112,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: transparent;
             }
 
-            @media only screen and (min-width: 641px) and (max-width: 1024px) {
-                /* hybrid */
-                #drawerLayout {
-                    --app-drawer-width: var(--app-layout-drawer-small-width);
-                    --app-layout-badge-width: var(--app-layout-badge-small-width);
-                    --app-layout-badge-height: var(--app-layout-badge-small-height);
-                    --app-layout-badge-top: var(--app-layout-badge-small-top);
-                    --app-layout-badge-right: var(--app-layout-badge-small-right);
-                    --app-layout-badge-color: transparent;
-                    --app-layout-menu-button-margin: 0;
-                    --app-layout-menu-button-padding: 0 21px;
-                    --app-layout-menu-padding: 0;
-                }
+            :host(:not([narrow]):not([wide])) #drawerLayout {
+                --app-drawer-width: var(--app-layout-drawer-small-width);
+                --app-layout-badge-width: var(--app-layout-badge-small-width);
+                --app-layout-badge-height: var(--app-layout-badge-small-height);
+                --app-layout-badge-top: var(--app-layout-badge-small-top);
+                --app-layout-badge-right: var(--app-layout-badge-small-right);
+                --app-layout-badge-color: transparent;
+                --app-layout-menu-button-margin: 0;
+                --app-layout-menu-button-padding: 0 21px;
+                --app-layout-menu-padding: 0;
+            }
 
-                #drawerLayout .app-menu-item {
-                    overflow: hidden;
-                }
+            :host(:not([narrow]):not([wide])) #drawerLayout .app-menu-item {
+                overflow: hidden;
+            }
 
-                #drawerLayout * {
-                    --expand-icon-fill-color: transparent !important;
-                    --app-layout-badge-font-color: transparent;
-                }
-
-                /* hybrid */
+            :host(:not([narrow]):not([wide])) #drawerLayout * {
+                --expand-icon-fill-color: transparent !important;
+                --app-layout-badge-font-color: transparent;
             }
         </style>
         <app-drawer-layout id="drawerLayout" fullbleed>
@@ -167,11 +153,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 <slot name="application-content"></slot>
             </div>
         </app-drawer-layout>
+        <iron-media-query query="[[_computeNarrowMediaQuery(responsiveWidthNarrow)]]" on-query-matches-changed="_onNarrowQueryMatchesChanged"></iron-media-query>
+        <iron-media-query query="[[_computeWideMediaQuery(responsiveWidthWide)]]" on-query-matches-changed="_onWideQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveHybridOverlayNoAppBar extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-hybrid-overlay-no-app-bar'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidthNarrow: {
+                        type: String,
+                        value: "640px",
+                    },
+                    responsiveWidthWide: {
+                        type: String,
+                        value: "1024px",
+                    },
+                };
+            }
+
+            static get observers() {
+                return [
+                    "_responsiveWidthChanged(responsiveWidthNarrow, responsiveWidthWide)"
+                ];
             }
 
             onclick() {
@@ -192,6 +199,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidthNarrow;
+            }
+
+            _onNarrowQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+            _onWideQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("wide", "");
+                else
+                    this.removeAttribute("wide");
+            }
+
+            _computeNarrowMediaQuery(responsiveWidthNarrow) {
+                return "(max-width: " + responsiveWidthNarrow + ")";
+            }
+
+            _computeWideMediaQuery(responsiveWidthWide) {
+                return "(min-width: " + responsiveWidthWide + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid.css
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid.css
@@ -1,27 +1,23 @@
-@media only screen and (min-width: 640px) {
-    app-layout-left-responsive-hybrid #menu-header-title, app-layout-left-responsive-hybrid #menu-header-subtitle {
-        opacity: 1.0;
-        transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
-        max-height: 50px;
-    }
-
-    app-layout-left-responsive-hybrid #menu-header-wrapper {
-        transition: padding 0.5s;
-    }
-
-    app-menu-icon-item {
-        transition: color 0.2s ease;
-    }
+app-layout-left-responsive-hybrid:not([narrow]) #menu-header-title
+app-layout-left-responsive-hybrid:not([narrow]) #menu-header-subtitle
+{
+    opacity: 1.0;
+    transition: opacity 0.2s, max-height 0.5s, margin-top 0.5s;
+    max-height: 50px;
 }
 
-@media only screen and (min-width: 641px) and (max-width: 1024px) {
-    app-layout-left-responsive-hybrid #menu-header-title, app-layout-left-responsive-hybrid #menu-header-subtitle {
-        opacity: 0;
-        max-height: 0px;
-        margin-top: 0px;
-    }
+app-layout-left-responsive-hybrid:not([narrow]) #menu-header-wrapper {
+    transition: padding 0.5s;
+}
 
-    app-layout-left-responsive-hybrid #menu-header-wrapper {
-        padding: 4px;
-    }
+app-layout-left-responsive-hybrid:not([narrow]):not([wide]) #menu-header-title,
+app-layout-left-responsive-hybrid:not([narrow]):not([wide]) #menu-header-subtitle
+{
+    opacity: 0;
+    max-height: 0px;
+    margin-top: 0px;
+}
+
+app-layout-left-responsive-hybrid:not([narrow]):not([wide]) #menu-header-wrapper {
+    padding: 4px;
 }

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-hybrid.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive-hybrid">
     <template>
@@ -83,18 +84,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 margin-left: -8px;
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle[icon="menu"] {
+            :host(:not([narrow])) #toggle[icon="menu"] {
                     display: none;
-                }
             }
 
-            @media only screen and (min-width: 640px) {
-
-
-                app-menu-icon-item {
-                    transition: color 0.2s ease;
-                }
+            :host(:not([narrow])) app-menu-icon-item {
+                transition: color 0.2s ease;
             }
 
             .application-content {
@@ -114,29 +109,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: transparent;
             }
 
-
-            @media only screen and (min-width: 641px) and (max-width: 1024px) {
-                #drawerLayout {
-                    --app-drawer-width: var(--app-layout-drawer-small-width);
-                    --app-layout-badge-width: var(--app-layout-badge-small-width);
-                    --app-layout-badge-height: var(--app-layout-badge-small-height);
-                    --app-layout-badge-top: var(--app-layout-badge-small-top);
-                    --app-layout-badge-right: var(--app-layout-badge-small-right);
-                    --app-layout-badge-color: transparent;
-                    --app-layout-menu-button-margin: 0;
-                    --app-layout-menu-button-padding: 0 21px;
-                    --app-layout-menu-padding: 0;
-                }
-
-                #drawerLayout .app-menu-item {
-                    overflow: hidden;
-                }
-
-                #drawerLayout {
-                    --expand-icon-fill-color: transparent !important;
-                    --app-layout-badge-font-color: transparent;
-                }
+            :host(:not([narrow]):not([wide])) #drawerLayout {
+                --app-drawer-width: var(--app-layout-drawer-small-width);
+                --app-layout-badge-width: var(--app-layout-badge-small-width);
+                --app-layout-badge-height: var(--app-layout-badge-small-height);
+                --app-layout-badge-top: var(--app-layout-badge-small-top);
+                --app-layout-badge-right: var(--app-layout-badge-small-right);
+                --app-layout-badge-color: transparent;
+                --app-layout-menu-button-margin: 0;
+                --app-layout-menu-button-padding: 0 21px;
+                --app-layout-menu-padding: 0;
             }
+
+            :host(:not([narrow]):not([wide])) #drawerLayout .app-menu-item {
+                overflow: hidden;
+            }
+
+            :host(:not([narrow]):not([wide])) #drawerLayout * {
+                --expand-icon-fill-color: transparent !important;
+                --app-layout-badge-font-color: transparent;
+            }
+
         </style>
         <app-header-layout id="layout-wrapper" fullbleed>
             <app-header fixed part="app-bar" slot="header">
@@ -160,11 +153,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </div>
             </app-drawer-layout>
         </app-header-layout>
+        <iron-media-query query="[[_computeNarrowMediaQuery(responsiveWidthNarrow)]]" on-query-matches-changed="_onNarrowQueryMatchesChanged"></iron-media-query>
+        <iron-media-query query="[[_computeWideMediaQuery(responsiveWidthWide)]]" on-query-matches-changed="_onWideQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveHybrid extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-hybrid'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidthNarrow: {
+                        type: String,
+                        value: "640px",
+                    },
+                    responsiveWidthWide: {
+                        type: String,
+                        value: "1024px",
+                    },
+                };
+            }
+
+            static get observers() {
+                return [
+                    "_responsiveWidthChanged(responsiveWidthNarrow, responsiveWidthWide)"
+                ];
             }
 
             onclick() {
@@ -185,6 +199,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidthNarrow;
+            }
+
+            _onNarrowQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+            _onWideQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("wide", "");
+                else
+                    this.removeAttribute("wide");
+            }
+
+            _computeNarrowMediaQuery(responsiveWidthNarrow) {
+                return "(max-width: " + responsiveWidthNarrow + ")";
+            }
+
+            _computeWideMediaQuery(responsiveWidthWide) {
+                return "(min-width: " + responsiveWidthWide + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-overlay-no-app-bar.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-overlay-no-app-bar.html
@@ -63,13 +63,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: var(--app-layout-background);
             }
 
-            @media only screen and (max-width: 640px) {
-                .application-content {
-                    box-sizing: border-box;
-                    padding-top: var(--app-layout-bar-height);
-                }
-            }
-
             #drawer {
                 --app-drawer-content-container: {
                     box-shadow: var(--app-layout-drawer-shadow);
@@ -98,21 +91,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 margin-left: -8px;
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle[icon="menu"] {
-                    display: none;
-                }
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
+            }
 
-                /* no-app-bar */
-                app-header {
-                    display: none;
-                }
+            :host(:not([narrow])) app-header {
+                display: none;
+            }
 
-                #drawer {
-                    margin-top: 0px;
-                }
+            :host(:not([narrow])) #drawer {
+                margin-top: 0px;
+            }
 
-                /* no-app-bar */
+            :host([narrow]) .application-content {
+                box-sizing: border-box;
+                padding-top: var(--app-layout-bar-height);
             }
         </style>
         <app-drawer-layout id="drawerLayout" fullbleed>
@@ -137,11 +130,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </slot>
             </div>
         </app-drawer-layout>
+        <iron-media-query query="[[_computeMediaQuery(responsiveWidth)]]" on-query-matches-changed="_onQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveOverlayNoAppBar extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-overlay-no-app-bar'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidth: {
+                        type: String,
+                        value: "640px",
+                        observer: "_responsiveWidthChanged"
+                    },
+                };
             }
 
             onclick() {
@@ -162,6 +166,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                console.log(this.responsiveWidth);
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidth;
+            }
+
+            _onQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+
+            _computeMediaQuery(responsiveWidth) {
+                return "(max-width: " + responsiveWidth + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-overlay.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-overlay.html
@@ -87,10 +87,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 margin-left: -8px;
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle[icon="menu"] {
-                    display: none;
-                }
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
             }
         </style>
         <app-drawer-layout id="drawerLayout" fullbleed>
@@ -113,11 +111,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 <slot name="application-content"></slot>
             </div>
         </app-drawer-layout>
+        <iron-media-query query="[[_computeMediaQuery(responsiveWidth)]]" on-query-matches-changed="_onQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveOverlay extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-overlay'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidth: {
+                        type: String,
+                        value: "640px",
+                        observer: "_responsiveWidthChanged"
+                    },
+                };
             }
 
             onclick() {
@@ -138,6 +147,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidth;
+            }
+
+            _onQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+
+            _computeMediaQuery(responsiveWidth) {
+                return "(max-width: " + responsiveWidth + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-overlay.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-overlay.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive-overlay">
     <template>

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small-no-app-bar.css
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small-no-app-bar.css
@@ -1,13 +1,11 @@
-@media only screen and (min-width: 640px) {
+app-layout-left-responsive-small-no-app-bar:not([narrow]) #menu-header-title,
+app-layout-left-responsive-small-no-app-bar:not([narrow]) #menu-header-subtitle
+{
+    opacity: 0;
+    max-height: 0px;
+    margin-top: 0px;
+}
 
-    app-layout-left-responsive-small-no-app-bar #menu-header-title, app-layout-left-responsive-small-no-app-bar #menu-header-subtitle {
-        opacity: 0;
-        max-height: 0px;
-        margin-top: 0px;
-    }
-
-    app-layout-left-responsive-small-no-app-bar #menu-header-wrapper {
-        padding: 4px;
-    }
-
+app-layout-left-responsive-small-no-app-bar:not([narrow]) #menu-header-wrapper {
+    padding: 4px;
 }

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small-no-app-bar.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small-no-app-bar.html
@@ -26,6 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive-small-no-app-bar">
     <template>
@@ -78,13 +79,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: var(--app-layout-background);
             }
 
-            @media only screen and (max-width: 640px) {
-                .application-content {
-                    padding-top: var(--app-layout-bar-height);
-                    box-sizing: border-box;
-                }
-            }
-
             #drawer {
                 --app-drawer-content-container: {
                     box-shadow: var(--app-layout-drawer-shadow);
@@ -112,47 +106,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: transparent;
             }
 
-            @media only screen and (min-width: 640px) {
-                /*responsive*/
-                #toggle[icon="menu"] {
-                    display: none;
-                }
-
-                /*responsive*/
-                /* small */
-                #drawerLayout {
-                    --app-drawer-width: var(--app-layout-drawer-small-width);
-                    --app-layout-badge-width: var(--app-layout-badge-small-width);
-                    --app-layout-badge-height: var(--app-layout-badge-small-height);
-                    --app-layout-badge-top: var(--app-layout-badge-small-top);
-                    --app-layout-badge-right: var(--app-layout-badge-small-right);
-                    --app-layout-badge-color: transparent;
-                    --app-layout-menu-button-margin: 0;
-                    --app-layout-menu-button-padding: 0 21px;
-                    --app-layout-menu-padding: 0;
-                }
-
-                #drawerLayout .app-menu-item {
-                    overflow: hidden;
-                }
-
-                #drawerLayout * {
-                    --expand-icon-fill-color: transparent !important;
-                    --app-layout-badge-font-color: transparent;
-                }
-
-                /* small */
-                /* no-app-bar */
-                app-header {
-                    display: none;
-                }
-
-                #drawer {
-                    margin-top: 0px;
-                }
-
-                /* no-app-bar */
+            :host([narrow]) .application-content {
+                padding-top: var(--app-layout-bar-height);
+                box-sizing: border-box;
             }
+
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
+            }
+
+            :host(:not([narrow])) #drawerLayout {
+                --app-drawer-width: var(--app-layout-drawer-small-width);
+                --app-layout-badge-width: var(--app-layout-badge-small-width);
+                --app-layout-badge-height: var(--app-layout-badge-small-height);
+                --app-layout-badge-top: var(--app-layout-badge-small-top);
+                --app-layout-badge-right: var(--app-layout-badge-small-right);
+                --app-layout-badge-color: transparent;
+                --app-layout-menu-button-margin: 0;
+                --app-layout-menu-button-padding: 0 21px;
+                --app-layout-menu-padding: 0;
+            }
+
+            :host(:not([narrow])) #drawerLayout .app-menu-item {
+                overflow: hidden;
+            }
+
+            :host(:not([narrow])) #drawerLayout * {
+                --expand-icon-fill-color: transparent !important;
+                --app-layout-badge-font-color: transparent;
+            }
+
+            :host(:not([narrow])) app-header {
+                display: none;
+            }
+
+            :host(:not([narrow])) #drawer {
+                margin-top: 0px;
+            }
+
         </style>
         <app-header-layout id="layout-wrapper" fullbleed>
             <app-header part="app-bar" fixed slot="header">
@@ -174,11 +165,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </div>
             </app-drawer-layout>
         </app-header-layout>
+        <iron-media-query query="[[_computeMediaQuery(responsiveWidth)]]" on-query-matches-changed="_onQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveSmallNoAppBar extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-small-no-app-bar'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidth: {
+                        type: String,
+                        value: "640px",
+                        observer: "_responsiveWidthChanged"
+                    },
+                };
             }
 
             onclick() {
@@ -199,6 +201,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidth;
+            }
+
+            _onQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+
+            _computeMediaQuery(responsiveWidth) {
+                return "(max-width: " + responsiveWidth + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small.css
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small.css
@@ -1,12 +1,11 @@
-@media only screen and (min-width: 640px) {
+app-layout-left-responsive-small:not([narrow]) #menu-header-title,
+app-layout-left-responsive-small:not([narrow]) #menu-header-subtitle
+{
+    opacity: 0;
+    max-height: 0px;
+    margin-top: 0px;
+}
 
-    app-layout-left-responsive-small #menu-header-title, app-layout-left-responsive-small #menu-header-subtitle {
-        opacity: 0;
-        max-height: 0px;
-        margin-top: 0px;
-    }
-
-    app-layout-left-responsive-small #menu-header-wrapper {
-        padding: 4px;
-    }
+app-layout-left-responsive-small:not([narrow]) #menu-header-wrapper {
+    padding: 4px;
 }

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive-small.html
@@ -26,6 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive-small">
     <template>
@@ -106,42 +107,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 margin-left: -8px;
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle {
-                    display: none;
-                }
+           :host(:not([narrow])) #toggle {
+                display: none;
             }
 
-            @media only screen and (min-width: 640px) {
-                /*responsive*/
-                #toggle[icon="menu"] {
-                    display: none;
-                }
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
+            }
 
-                /*responsive*/
-                /* small */
-                #drawerLayout {
-                    --app-drawer-width: var(--app-layout-drawer-small-width);
-                    --app-layout-badge-width: var(--app-layout-badge-small-width);
-                    --app-layout-badge-height: var(--app-layout-badge-small-height);
-                    --app-layout-badge-top: var(--app-layout-badge-small-top);
-                    --app-layout-badge-right: var(--app-layout-badge-small-right);
-                    --app-layout-badge-color: transparent;
-                    --app-layout-menu-button-margin: 0;
-                    --app-layout-menu-button-padding: 0 21px;
-                    --app-layout-menu-padding: 0;
-                }
+            :host(:not([narrow])) #drawerLayout {
+                --app-drawer-width: var(--app-layout-drawer-small-width);
+                --app-layout-badge-width: var(--app-layout-badge-small-width);
+                --app-layout-badge-height: var(--app-layout-badge-small-height);
+                --app-layout-badge-top: var(--app-layout-badge-small-top);
+                --app-layout-badge-right: var(--app-layout-badge-small-right);
+                --app-layout-badge-color: transparent;
+                --app-layout-menu-button-margin: 0;
+                --app-layout-menu-button-padding: 0 21px;
+                --app-layout-menu-padding: 0;
+            }
 
-                #drawerLayout .app-menu-item {
-                    overflow: hidden;
-                }
+            :host(:not([narrow])) #drawerLayout .app-menu-item {
+                overflow: hidden;
+            }
 
-                #drawerLayout * {
-                    --expand-icon-fill-color: transparent !important;
-                    --app-layout-badge-font-color: transparent;
-                }
-
-                /* small */
+            :host(:not([narrow])) #drawerLayout * {
+                --expand-icon-fill-color: transparent !important;
+                --app-layout-badge-font-color: transparent;
             }
         </style>
         <app-header-layout id="layout-wrapper" fullbleed>
@@ -165,11 +157,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </div>
             </app-drawer-layout>
         </app-header-layout>
+        <iron-media-query query="[[_computeMediaQuery(responsiveWidth)]]" on-query-matches-changed="_onQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsiveSmall extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive-small'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidth: {
+                        type: String,
+                        value: "640px",
+                        observer: "_responsiveWidthChanged"
+                    },
+                };
             }
 
             onclick() {
@@ -190,6 +193,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidth;
+            }
+
+            _onQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+
+            _computeMediaQuery(responsiveWidth) {
+                return "(max-width: " + responsiveWidth + ")";
             }
         }
 

--- a/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive.html
+++ b/app-layout-addon/src/main/resources/META-INF/resources/frontend/src/com/github/appreciated/app-layout/left/left-responsive.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../../../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../../../bower_components/iron-media-query/iron-media-query.html">
 
 <dom-module id="app-layout-left-responsive">
     <template>
@@ -97,10 +98,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 background: var(--app-layout-background);
             }
 
-            @media only screen and (min-width: 640px) {
-                #toggle[icon="menu"] {
-                    display: none;
-                }
+            :host(:not([narrow])) #toggle[icon="menu"] {
+                display: none;
             }
         </style>
         <app-header-layout id="layout-wrapper" fullbleed>
@@ -125,11 +124,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </div>
             </app-drawer-layout>
         </app-header-layout>
+        <iron-media-query query="[[_computeMediaQuery(responsiveWidth)]]" on-query-matches-changed="_onQueryMatchesChanged"></iron-media-query>
     </template>
     <script>
         class AppLayoutLeftResponsive extends Vaadin.ThemableMixin(Polymer.Element){
             static get is() {
                 return 'app-layout-left-responsive'
+            }
+
+            static get properties() {
+                return {
+                     responsiveWidth: {
+                        type: String,
+                        value: "640px",
+                        observer: "_responsiveWidthChanged"
+                    },
+                };
             }
 
             onclick() {
@@ -150,6 +160,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 if (!drawer.persistent) {
                     drawer.close();
                 }
+            }
+
+            _responsiveWidthChanged() {
+                Polymer.dom(this.root).querySelector("#drawerLayout").responsiveWidth = this.responsiveWidth;
+            }
+
+            _onQueryMatchesChanged(event) {
+                if (event.detail.value)
+                    this.setAttribute("narrow", "");
+                else
+                    this.removeAttribute("narrow");
+            }
+
+            _computeMediaQuery(responsiveWidth) {
+                return "(max-width: " + responsiveWidth + ")";
             }
         }
 


### PR DESCRIPTION
Add ability to set the `responsiveWidth` for all `LeftResponsive`-Behaviours.
The `LeftResponsiveHybrid`-Behaviours use `responsiveWidthNarrow` and `responsiveWidthWide` instead.
The specified `width` is always used as `min-width`, to avoid intersections.

Close #237 