### PR TITLE
Add working dependency injection example for spring

### DIFF
--- a/app-layout-examples/app-layout-spring-example/src/main/java/com/github/appreciated/spring/MainAppLayout.java
+++ b/app-layout-examples/app-layout-spring-example/src/main/java/com/github/appreciated/spring/MainAppLayout.java
@@ -26,8 +26,7 @@ import static com.github.appreciated.app.layout.entity.Section.HEADER;
 @Push
 @Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
 @PWA(name = "Project Base for Vaadin Flow with Spring", shortName = "Project Base")
-@Component
-@UIScope
+@Component @UIScope // optional but useful; allows access to this instance from views, see View1.
 public class MainAppLayout extends AppLayoutRouterLayout<LeftLayouts.LeftResponsive> {
     private DefaultNotificationHolder notifications = new DefaultNotificationHolder();
     private DefaultBadgeHolder badge = new DefaultBadgeHolder(5);

--- a/app-layout-examples/app-layout-spring-example/src/main/java/com/github/appreciated/spring/MainAppLayout.java
+++ b/app-layout-examples/app-layout-spring-example/src/main/java/com/github/appreciated/spring/MainAppLayout.java
@@ -17,6 +17,8 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.server.PWA;
+import com.vaadin.flow.spring.annotation.UIScope;
+import org.springframework.stereotype.Component;
 
 import static com.github.appreciated.app.layout.entity.Section.FOOTER;
 import static com.github.appreciated.app.layout.entity.Section.HEADER;
@@ -24,6 +26,8 @@ import static com.github.appreciated.app.layout.entity.Section.HEADER;
 @Push
 @Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
 @PWA(name = "Project Base for Vaadin Flow with Spring", shortName = "Project Base")
+@Component
+@UIScope
 public class MainAppLayout extends AppLayoutRouterLayout<LeftLayouts.LeftResponsive> {
     private DefaultNotificationHolder notifications = new DefaultNotificationHolder();
     private DefaultBadgeHolder badge = new DefaultBadgeHolder(5);

--- a/app-layout-examples/app-layout-spring-example/src/main/java/com/github/appreciated/spring/View1.java
+++ b/app-layout-examples/app-layout-spring-example/src/main/java/com/github/appreciated/spring/View1.java
@@ -10,19 +10,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Route(value = "", layout = MainAppLayout.class)
 public class View1 extends VerticalLayout {
 
-    public View1(@Autowired MessageBean bean) {
+    public View1(@Autowired MessageBean bean, @Autowired MainAppLayout appLayout) {
 
     	Button button = new Button("Click me",
                 e -> Notification.show(bean.getMessage()));
         add(button);
 
-        add(getLabel());
-        add(getLabel());
-        add(getLabel());
-        add(getLabel());
-        add(getLabel());
-        add(getLabel());
+        // can access the AppLayout instance via dependency injection
+        int notificationCount = appLayout.getNotifications().getNotificationSize();
+        add(new Paragraph("You have "+notificationCount+" notification(s)"));
 
+        add(getLabel());
+        add(getLabel());
+        add(getLabel());
+        add(getLabel());
+        add(getLabel());
+        add(getLabel());
 
     }
 


### PR DESCRIPTION
In this patch, I've registered the `AppLayout` (`MainAppLayout`) as a UI scope bean, then injected it to `View1`. It allows easy access to the `MainAppLayout` instance and its methods from the view instance directly and serves as a good example.

By the way, thanks for your hard work, the responsive menu is super useful!